### PR TITLE
Secure sheets debug endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,20 @@ This site is deployed on Vercel and connected to GitHub for continuous deploymen
 Based in Sydney, Australia
 - Instagram: [@sydneymotocoach](https://www.instagram.com/sydneymotocoach/)
 - Facebook: [TheMotocoach](https://www.facebook.com/TheMotocoach/)
+
+## Sheets Debug Endpoint
+
+An optional `/api/sheets-debug` route can be enabled to help diagnose Google Sheets
+integrations. The endpoint is disabled by default. To use it in a secure
+environment:
+
+- Set `SHEETS_DEBUG_ENABLED=true` to expose the route.
+- Provide a comma-separated list of trusted origins in
+  `SHEETS_DEBUG_ALLOWED_ORIGINS` (e.g. `https://admin.example.com`). Requests from
+  other origins are rejected.
+- Configure a shared secret in `SHEETS_DEBUG_API_KEY` and supply it via the
+  `x-api-key` request header. Requests without the correct key receive a `401`
+  response.
+
+The endpoint continues to rely on the existing Google Sheets credentials and ID
+environment variables.

--- a/api/sheets-debug.js
+++ b/api/sheets-debug.js
@@ -1,14 +1,78 @@
 // Debug endpoint to see Google Sheets data
 const { google } = require('googleapis');
 
+const isSheetsDebugEnabled = () => process.env.SHEETS_DEBUG_ENABLED === 'true';
+
+const getAllowedOrigins = () => {
+    const origins = process.env.SHEETS_DEBUG_ALLOWED_ORIGINS;
+    if (!origins) {
+        return [];
+    }
+
+    return origins
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean);
+};
+
+const isOriginAllowed = (origin, allowedOrigins) => {
+    if (!origin) {
+        return false;
+    }
+
+    return allowedOrigins.includes(origin);
+};
+
+const getRequiredApiKey = () => process.env.SHEETS_DEBUG_API_KEY;
+
+const extractApiKeyFromRequest = (req) => {
+    const headerValue = req.headers['x-api-key'];
+    if (Array.isArray(headerValue)) {
+        return headerValue[0];
+    }
+    return headerValue;
+};
+
 export default async function handler(req, res) {
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    if (!isSheetsDebugEnabled()) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+    }
+
+    const allowedOrigins = getAllowedOrigins();
+    const requestOrigin = req.headers.origin || '';
+
+    if (!isOriginAllowed(requestOrigin, allowedOrigins)) {
+        res.status(403).json({ error: 'Origin not allowed' });
+        return;
+    }
+
+    const requiredApiKey = getRequiredApiKey();
+    if (!requiredApiKey) {
+        res.status(500).json({ error: 'Debug endpoint is not configured' });
+        return;
+    }
+
+    // Set CORS headers for allowed origins
+    res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+    res.setHeader('Vary', 'Origin');
     res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-API-Key');
 
     if (req.method === 'OPTIONS') {
         res.status(200).end();
+        return;
+    }
+
+    if (req.method !== 'GET') {
+        res.status(405).json({ error: 'Method not allowed' });
+        return;
+    }
+
+    const providedApiKey = extractApiKeyFromRequest(req);
+
+    if (!providedApiKey || providedApiKey !== requiredApiKey) {
+        res.status(401).json({ error: 'Invalid API key' });
         return;
     }
 
@@ -30,7 +94,7 @@ export default async function handler(req, res) {
         });
 
         const rows = response.data.values || [];
-        
+
         // Also test the specific range we use in production
         const prodResponse = await sheets.spreadsheets.values.get({
             spreadsheetId,
@@ -50,7 +114,7 @@ export default async function handler(req, res) {
             all_data_A1_C20: rows.map((row, index) => ({
                 row_number: index + 1,
                 column_A: row[0] || 'empty',
-                column_B: row[1] || 'empty', 
+                column_B: row[1] || 'empty',
                 column_C: row[2] || 'empty'
             })),
             production_data_A3_C: prodRows.map((row, index) => ({
@@ -65,7 +129,7 @@ export default async function handler(req, res) {
                 matches: prodRows.filter(row => {
                     const sheetEventName = row[1] || '';
                     const sheetEventDate = row[2] || '';
-                    return sheetEventName.trim().toLowerCase() === 'clubmx' && 
+                    return sheetEventName.trim().toLowerCase() === 'clubmx' &&
                            sheetEventDate.trim() === '11/09/2025';
                 })
             }


### PR DESCRIPTION
## Summary
- gate the `/api/sheets-debug` route behind an environment flag, origin whitelist, and API key validation
- limit CORS headers to trusted origins and enforce authentication before returning sheet data
- document the environment variables required to enable the debug endpoint safely

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8b0bd0b3c8322a37b8fdc9efddbc2