### PR TITLE
Enhance mobile styling across key pages

### DIFF
--- a/styles/calendar.css
+++ b/styles/calendar.css
@@ -1123,20 +1123,35 @@ div:focus {
 
 /* Mobile Calendar Styles */
 @media (max-width: 768px) {
-    .calendar-hero h1 {
-        font-size: 2rem;
+    .calendar-hero {
+        padding: 90px clamp(1.25rem, 6vw, 1.8rem) 52px clamp(1.25rem, 6vw, 1.8rem);
+        background: radial-gradient(circle at top, rgba(255, 107, 53, 0.18), rgba(18, 18, 18, 0.92));
+        color: #f5f5f5;
+        border-radius: 0 0 30px 30px;
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+        text-align: center;
     }
-    
+
+    .calendar-hero h1 {
+        font-size: clamp(1.85rem, 6vw, 2.2rem);
+        letter-spacing: 2px;
+        text-shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
+    }
+
     .calendar-hero p {
         font-size: 1rem;
-        padding: 0 1rem;
+        padding: 0 clamp(1rem, 5vw, 1.5rem);
+        color: rgba(255, 255, 255, 0.75);
     }
-    
+
     .calendar-header {
-        padding: 1rem 0.5rem;
-        border-radius: 8px 8px 0 0;
+        padding: clamp(0.85rem, 4vw, 1.1rem) clamp(0.75rem, 4vw, 1.25rem);
+        border-radius: 18px 18px 0 0;
+        background: rgba(22, 22, 22, 0.92);
+        border: 1px solid rgba(255, 107, 53, 0.18);
+        box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
     }
-    
+
     .month-year h2 {
         font-size: 1.4rem;
         letter-spacing: 1px;
@@ -1185,33 +1200,37 @@ div:focus {
     }
     
     .event-panel {
-        padding: 1rem 0.5rem;
+        padding: clamp(1.25rem, 5vw, 1.75rem) clamp(1rem, 5vw, 1.5rem);
     }
-    
+
     .event-panel h3 {
         font-size: 1.2rem;
         text-align: center;
     }
-    
+
     .calendar-wrapper {
-        margin: 0; /* Full width on mobile */
-        border-radius: 0; /* Remove border radius for full-width */
+        margin: clamp(1.5rem, 6vw, 2.25rem) clamp(1rem, 5vw, 1.75rem);
+        border-radius: 22px;
         overflow: hidden;
+        background: rgba(13, 13, 13, 0.92);
+        border: 1px solid rgba(255, 107, 53, 0.15);
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
     }
 
     /* Mobile: Stack event panel on top, calendar below */
     .calendar-main-container {
         flex-direction: column;
     }
-    
+
     .calendar-main-container .event-panel {
         flex: 0 0 auto;
         max-height: 300px;
         border-right: none;
-        border-bottom: 1px solid #333;
-        padding: 2rem;
+        border-bottom: 1px solid rgba(255, 107, 53, 0.18);
+        padding: clamp(1.5rem, 6vw, 2.25rem);
+        background: rgba(16, 16, 16, 0.9);
     }
-    
+
     .calendar-main-container .calendar-section {
         flex: 1;
         padding: 0;
@@ -1226,6 +1245,14 @@ div:focus {
         max-width: 100% !important;
         overflow: hidden !important;
         padding: 1rem !important;
+    }
+
+    .event-item {
+        background: rgba(255, 255, 255, 0.05) !important;
+        border: 1px solid rgba(255, 107, 53, 0.12) !important;
+        border-radius: 16px !important;
+        padding: clamp(1rem, 4vw, 1.4rem) !important;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35) !important;
     }
     
     .mobile-week-view .calendar-day {
@@ -1327,49 +1354,54 @@ div:focus {
 
 /* Extra Small Mobile Styles */
 @media (max-width: 480px) {
+    .calendar-hero {
+        padding: 80px clamp(1rem, 7vw, 1.5rem) 45px clamp(1rem, 7vw, 1.5rem);
+        border-radius: 0 0 24px 24px;
+    }
+
     .calendar-wrapper {
-        margin: 0; /* Full width on extra small mobile */
+        margin: clamp(1rem, 6vw, 1.5rem);
     }
-    
+
     .calendar-header {
-        padding: 0.75rem 1rem;
-        border-radius: 0;
+        padding: 0.7rem 1rem;
+        border-radius: 16px 16px 0 0;
     }
-    
+
     .month-year h2 {
         font-size: 1.2rem;
         letter-spacing: 0.5px;
     }
-    
+
     .nav-btn {
         width: 34px;
         height: 34px;
         font-size: 0.9rem;
         border-radius: 5px;
     }
-    
+
     .day-header {
         padding: 0.4rem 0.1rem;
         font-size: 0.65rem;
     }
-    
+
     .calendar-day {
         min-height: 60px;
         padding: 0.2rem;
         font-size: 0.8rem;
     }
-    
+
     .day-number {
         font-size: 0.7rem;
     }
-    
+
     .event-preview {
         font-size: 0.5rem;
         padding: 1px;
     }
-    
+
     .event-panel {
-        padding: 0.75rem 0.25rem;
+        padding: clamp(1rem, 6vw, 1.4rem) clamp(0.75rem, 6vw, 1.1rem);
     }
     
     /* Mobile Event Panel Styles */

--- a/styles/index.css
+++ b/styles/index.css
@@ -522,30 +522,49 @@ main {
     }
 
     .hero-content {
-        padding: 0 clamp(1.25rem, 5vw, 2rem);
+        padding: clamp(1.5rem, 6vw, 2.25rem);
+        margin: 0 clamp(1.1rem, 6vw, 2.25rem);
+        background: linear-gradient(180deg, rgba(0, 0, 0, 0.85) 0%, rgba(0, 0, 0, 0.55) 100%);
+        border-radius: 24px;
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(8px);
     }
 
     .hero-content h1 {
         font-size: clamp(1.8rem, 6vw, 3rem);
         letter-spacing: 2px;
+        text-shadow: 0 6px 18px rgba(0, 0, 0, 0.6);
     }
 
     .hero-content p {
         font-size: clamp(1rem, 4.5vw, 1.3rem);
         line-height: 1.6;
         margin-bottom: clamp(1.5rem, 6vw, 2rem);
+        color: rgba(255, 255, 255, 0.85);
+        text-shadow: 0 4px 14px rgba(0, 0, 0, 0.5);
     }
-    
+
     .slide img {
         object-position: center center;
         filter: brightness(0.8) contrast(1.2);
     }
-    
+
     /* CTA Button mobile styles */
     .cta-btn {
-        padding: clamp(0.85rem, 3.5vw, 1rem) clamp(1.75rem, 6vw, 2.5rem);
-        font-size: clamp(1rem, 3.5vw, 1.1rem);
-        border-radius: 45px;
+        padding: clamp(0.9rem, 3.8vw, 1.1rem) clamp(1.9rem, 6.4vw, 2.6rem);
+        font-size: clamp(1rem, 3.5vw, 1.15rem);
+        border-radius: 999px;
+        width: min(100%, 320px);
+    }
+
+    .services-section {
+        color: rgba(245, 245, 245, 0.85);
+    }
+
+    .services-section .section-title {
+        color: #ffffff;
+        text-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+        letter-spacing: 2px;
     }
 
     .services-grid {
@@ -555,57 +574,91 @@ main {
 
     .service-item {
         text-align: center;
+        background: radial-gradient(circle at top, rgba(255, 107, 53, 0.12), rgba(26, 26, 26, 0.85));
+        border-radius: 22px;
+        padding: clamp(1.25rem, 5vw, 1.75rem) clamp(1rem, 4vw, 1.5rem) clamp(1.5rem, 5vw, 2rem);
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+        border: 1px solid rgba(255, 107, 53, 0.15);
     }
 
     .service-image {
         height: clamp(200px, 55vw, 260px);
+        border-radius: 16px;
+        object-fit: cover;
+        box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35);
     }
 
     .service-item h3 {
         font-size: clamp(1.2rem, 4.5vw, 1.6rem);
+        margin-top: clamp(1.1rem, 4vw, 1.5rem);
+        color: #f8f9fa;
+        letter-spacing: 1px;
     }
-    
+
     /* Sponsors section mobile styles */
     .sponsors-section {
         margin-top: clamp(3rem, 12vw, 4.5rem);
+        padding: clamp(2rem, 7vw, 3rem) clamp(1.25rem, 5vw, 2.5rem);
+        background: linear-gradient(180deg, rgba(26, 26, 26, 0.92) 0%, rgba(15, 15, 15, 0.92) 100%);
+        border-radius: 24px;
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+    }
+
+    .sponsors-section .section-title {
+        color: #ffffff;
+        font-size: clamp(1.8rem, 5.5vw, 2.2rem);
+        text-shadow: 0 8px 26px rgba(0, 0, 0, 0.45);
     }
 
     .sponsors-grid {
         flex-direction: column;
         gap: clamp(1.5rem, 6vw, 2.5rem);
     }
-    
+
     .sponsor-image {
         max-width: clamp(100px, 25vw, 150px);
         max-height: clamp(60px, 15vw, 90px);
+        filter: brightness(1.08) contrast(1.1);
     }
-    
+
     .about-section {
-        padding: clamp(45px, 12vw, 70px) clamp(1.25rem, 5vw, 1.75rem);
+        padding: clamp(48px, 13vw, 74px) clamp(1.5rem, 6vw, 2.25rem);
+        background: radial-gradient(circle at top, rgba(255, 107, 53, 0.14), rgba(12, 12, 12, 0.95));
+        border-radius: 0 0 32px 32px;
     }
 
     /* About section mobile styles */
     .about-container {
         grid-template-columns: 1fr;
+        gap: clamp(1.5rem, 5vw, 2rem);
     }
-    
+
     .about-image-side {
         display: none;
     }
-    
+
     .about-content-side {
         order: 1;
-        padding: clamp(0.5rem, 2vw, 1rem) 0;
+        padding: clamp(1.5rem, 6vw, 2.25rem);
         max-width: 650px;
         margin: 0 auto;
+        background: rgba(14, 14, 14, 0.9);
+        border-radius: 24px;
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+        border: 1px solid rgba(255, 107, 53, 0.12);
     }
 
     .about-description {
         margin-bottom: clamp(2rem, 8vw, 3rem);
+        display: grid;
+        gap: clamp(1rem, 4vw, 1.5rem);
     }
 
     .about-description p {
         text-align: center;
+        color: rgba(232, 232, 232, 0.85);
+        font-size: clamp(0.95rem, 3.8vw, 1.05rem);
+        line-height: 1.7;
     }
 
     .about-stats {
@@ -619,6 +672,10 @@ main {
 
     .stat-item {
         padding: clamp(1rem, 4vw, 1.5rem);
+        background: linear-gradient(160deg, rgba(255, 107, 53, 0.28), rgba(24, 24, 24, 0.95));
+        border-radius: 18px;
+        border: 1px solid rgba(255, 107, 53, 0.25);
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
         aspect-ratio: auto;
         display: flex;
         flex-direction: column;
@@ -635,14 +692,20 @@ main {
 
     .stat-number {
         font-size: clamp(1.6rem, 7vw, 2.3rem);
+        color: #fff;
+        letter-spacing: 1px;
     }
 
     .stat-label {
         font-size: clamp(0.85rem, 3vw, 1rem);
+        color: rgba(255, 255, 255, 0.8);
+        letter-spacing: 1.2px;
     }
 
     .about-highlight {
         margin-bottom: clamp(0.6rem, 3vw, 1.4rem);
+        color: #ff6b35;
+        letter-spacing: 2.2px;
     }
 
     /* Show mobile programs subtitle on mobile only */
@@ -663,13 +726,19 @@ main {
 @media (max-width: 480px) {
     /* CTA Button extra small mobile styles */
     .cta-btn {
-        padding: 12px 25px;
+        padding: 0.85rem 1.6rem;
         font-size: 1rem;
         letter-spacing: 1px;
+        width: 100%;
     }
 
     .hero {
         padding-bottom: clamp(3rem, 22vw, 5rem);
+    }
+
+    .hero-content {
+        margin: 0 clamp(0.85rem, 6vw, 1.25rem);
+        border-radius: 20px;
     }
 
     .hero-content h1 {
@@ -681,11 +750,16 @@ main {
     }
 
     .services-grid {
-        padding: 0 clamp(0.8rem, 6vw, 1.2rem);
+        padding: 0 clamp(0.75rem, 6vw, 1.1rem);
+    }
+
+    .service-item {
+        padding: clamp(1.1rem, 6vw, 1.5rem) clamp(0.9rem, 5vw, 1.3rem) clamp(1.35rem, 6vw, 1.9rem);
+        border-radius: 20px;
     }
 
     .about-content-side {
-        padding: 0;
+        padding: clamp(1.2rem, 6vw, 1.85rem);
     }
 
     /* Extra mobile centering for about stats on small screens */
@@ -697,7 +771,8 @@ main {
     }
 
     .stat-item {
-        padding: clamp(0.9rem, 5vw, 1.2rem);
+        padding: clamp(0.95rem, 6vw, 1.3rem);
+        border-radius: 16px;
     }
 
     .mobile-programs-subtitle {

--- a/styles/shop.css
+++ b/styles/shop.css
@@ -1634,22 +1634,90 @@
 
 @media (max-width: 768px) {
     .shop-hero {
-        padding: 100px 1rem 40px 1rem;
+        padding: 110px clamp(1.25rem, 6vw, 2rem) 55px clamp(1.25rem, 6vw, 2rem);
+        background: radial-gradient(circle at top, rgba(255, 107, 53, 0.18), rgba(16, 16, 16, 0.92));
+        color: #f5f5f5;
+        border-radius: 0 0 32px 32px;
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.4);
+        text-align: center;
     }
-    
+
+    .shop-hero h1 {
+        color: #ffffff;
+        letter-spacing: 2px;
+        text-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+    }
+
     .shop-controls {
-        padding: 1.5rem;
-        margin-top: 2rem;
+        padding: clamp(1.35rem, 6vw, 1.85rem);
+        margin-top: clamp(1.75rem, 6vw, 2.5rem);
+        flex-direction: column;
+        align-items: stretch;
+        gap: clamp(1.15rem, 5vw, 1.75rem);
+        background: rgba(15, 15, 15, 0.9);
+        border-radius: 22px;
+        border: 1px solid rgba(255, 107, 53, 0.2);
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+        color: rgba(245, 245, 245, 0.85);
     }
-    
+
+    .filters-header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+    }
+
+    .filters-header .filters-meta {
+        justify-content: space-between;
+    }
+
+    .filters h3 {
+        color: #ffffff;
+        letter-spacing: 2px;
+    }
+
+    .results-inline {
+        color: rgba(255, 255, 255, 0.7);
+    }
+
     .filter-buttons {
-        justify-content: center;
+        justify-content: flex-start;
+        gap: 0.5rem;
     }
-    
+
+    .filter-btn {
+        background: rgba(255, 255, 255, 0.08);
+        color: #f5f5f5;
+        border: 1px solid rgba(255, 107, 53, 0.25);
+    }
+
+    .filter-btn.active {
+        background: rgba(255, 107, 53, 0.25);
+        border-color: rgba(255, 107, 53, 0.45);
+    }
+
     .products-grid {
         grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-        gap: 1rem;
-        padding: 0 1rem;
+        gap: clamp(1.1rem, 4vw, 1.75rem);
+        padding: 0 clamp(0.85rem, 5vw, 1.5rem);
+    }
+
+    .product-card {
+        border-radius: 22px;
+        overflow: hidden;
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.32);
+    }
+
+    .product-image {
+        height: clamp(210px, 62vw, 260px);
+    }
+
+    .product-info {
+        padding: clamp(1.35rem, 5vw, 1.85rem);
+    }
+
+    .price-current {
+        font-size: clamp(1.2rem, 5vw, 1.4rem);
     }
     
     .modal-product {
@@ -1804,28 +1872,39 @@
 }
 
 @media (max-width: 480px) {
+    .shop-hero {
+        padding: 100px clamp(1rem, 7vw, 1.5rem) 48px clamp(1rem, 7vw, 1.5rem);
+        border-radius: 0 0 28px 28px;
+    }
+
     .shop-hero h1 {
-        font-size: 2rem;
+        font-size: clamp(1.85rem, 8vw, 2.1rem);
     }
-    
+
     .shop-controls {
-        padding: 1rem;
+        padding: clamp(1.1rem, 6vw, 1.4rem);
+        border-radius: 20px;
     }
-    
+
     .filter-btn {
-        padding: 0.5rem 1rem;
+        padding: 0.45rem 0.9rem;
         font-size: 0.8rem;
     }
-    
+
     .products-grid {
         grid-template-columns: 1fr;
-        padding: 0 0.5rem;
+        padding: 0 clamp(0.6rem, 6vw, 1rem);
+        gap: clamp(0.9rem, 5vw, 1.25rem);
     }
-    
+
+    .product-card {
+        border-radius: 20px;
+    }
+
     .product-actions {
         flex-direction: column;
     }
-    
+
     .btn-quick-view {
         width: 100%;
         height: auto;


### PR DESCRIPTION
## Summary
- Refresh the landing page mobile sections with gradient hero container, card-style program tiles, and improved typography for readability on small screens.
- Update the shop mobile experience with a darker hero treatment, refined filter chips, and tighter product card spacing.
- Polish the calendar mobile layout by adding card surfaces, gradients, and softer margins for the hero, event list, and schedule grid.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca07b6da7c8322ba3f35f1274ab72c