### PR TITLE
Remove shop FAQ section

### DIFF
--- a/shop.html
+++ b/shop.html
@@ -213,25 +213,6 @@
                 </div>
             </div>
         </div>
-        <section class="shop-faq" aria-labelledby="shop-faq-title">
-            <div class="shop-faq-container">
-                <h2 id="shop-faq-title">Moto Coach Shop FAQs</h2>
-                <div class="shop-faq-grid">
-                    <article class="faq-item">
-                        <h3>Do you ship across Australia?</h3>
-                        <p>Yes. We dispatch apparel and training equipment Australia-wide with tracking, and Sydney riders can arrange collection at a Moto Coach coaching session.</p>
-                    </article>
-                    <article class="faq-item">
-                        <h3>Can I try gear before buying?</h3>
-                        <p>Riders booked into our coaching programs can trial select items trackside so you can confirm sizing and fit before ordering online.</p>
-                    </article>
-                    <article class="faq-item">
-                        <h3>Which products suit my skill level?</h3>
-                        <p>Each listing includes coaching notes from Leigh that explain who the gear is designed for. Contact us if you need personalised recommendations for your riding goals.</p>
-                    </article>
-                </div>
-            </div>
-        </section>
     </main>
 
     <!-- Product Modal -->


### PR DESCRIPTION
## Summary
- remove the Moto Coach Shop FAQ block from the shop page since it is no longer needed

## Testing
- not run (static markup change)


------
https://chatgpt.com/codex/tasks/task_e_68ccc3fd68c883228b4c1db9658631d5