### PR TITLE
Fix mobile header social icons display

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -602,8 +602,19 @@ footer {
         gap: clamp(0.75rem, 4vw, 1.25rem);
     }
 
-    .social-icons {
-        display: none;
+    .nav-right .social-icons {
+        display: flex;
+        order: 1;
+        gap: clamp(0.5rem, 3vw, 1rem);
+    }
+
+    .nav-right .social-icon svg {
+        width: clamp(18px, 4vw, 22px);
+        height: clamp(18px, 4vw, 22px);
+    }
+
+    .nav-right .mobile-menu-toggle {
+        order: 2;
     }
 
     /* Universal header (other pages) mobile styles */


### PR DESCRIPTION
## Summary
- restore the header social icons on mobile and half-width layouts
- arrange the icons to sit just left of the hamburger toggle with responsive spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd185618c83228171a4feedf4f7f3