### PR TITLE
Disable reCAPTCHA outside live deployments

### DIFF
--- a/api/_utils/environment.js
+++ b/api/_utils/environment.js
@@ -1,0 +1,43 @@
+const LIVE_BRANCHES = new Set(['main']);
+
+function getCurrentBranch() {
+  const branch = process.env.VERCEL_GIT_COMMIT_REF || process.env.GIT_BRANCH || process.env.BRANCH || '';
+  return branch.trim().toLowerCase();
+}
+
+function getVercelEnv() {
+  return (process.env.VERCEL_ENV || '').trim().toLowerCase();
+}
+
+function getNodeEnv() {
+  return (process.env.NODE_ENV || '').trim().toLowerCase();
+}
+
+export function isLiveEnvironment() {
+  const branch = getCurrentBranch();
+  const vercelEnv = getVercelEnv();
+
+  if (vercelEnv && vercelEnv !== 'production') {
+    return false;
+  }
+
+  if (branch) {
+    return LIVE_BRANCHES.has(branch);
+  }
+
+  const nodeEnv = getNodeEnv();
+  if (nodeEnv && nodeEnv !== 'production') {
+    return false;
+  }
+
+  return true;
+}
+
+export function getEnvironmentDetails() {
+  return {
+    branch: getCurrentBranch(),
+    vercelEnv: getVercelEnv(),
+    nodeEnv: getNodeEnv(),
+    isLive: isLiveEnvironment(),
+  };
+}

--- a/api/config.js
+++ b/api/config.js
@@ -1,4 +1,5 @@
 import { applyCors } from './_utils/cors';
+import { isLiveEnvironment } from './_utils/environment';
 
 export default async function handler(req, res) {
     const cors = applyCors(req, res, {
@@ -16,8 +17,10 @@ export default async function handler(req, res) {
 
     try {
         // Only return public configuration that's safe to expose
+        const recaptchaEnabled = isLiveEnvironment();
         const config = {
-            recaptchaSiteKey: process.env.RECAPTCHA_SITE_KEY,
+            recaptchaEnabled,
+            recaptchaSiteKey: recaptchaEnabled ? process.env.RECAPTCHA_SITE_KEY : null,
             // Add other public config here if needed
         };
 


### PR DESCRIPTION
## Summary
- add a shared environment helper to determine when the app is running on the live main branch
- gate reCAPTCHA enforcement in API routes so verification only occurs for live deployments while returning the flag in config
- teach front-end forms to read the config, hide the widget, and skip token handling when reCAPTCHA is disabled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf87acdcf88322a3f73f07c1bb9d4d