### PR TITLE
Ensure mobile text stays left aligned on home and US camp pages

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -632,7 +632,11 @@ main {
     }
 
     .about-description p {
-        text-align: center;
+        text-align: left !important;
+    }
+
+    .about-content-side p {
+        text-align: left !important;
     }
 
     .about-stats {

--- a/styles/us.css
+++ b/styles/us.css
@@ -1010,8 +1010,15 @@
     
     .detail-info {
         padding: 0 1rem;
+        text-align: left !important;
+        margin-left: 0;
+        margin-right: 0;
     }
-    
+
+    .detail-info p {
+        text-align: left !important;
+    }
+
     .experience-detail {
         padding: 60px 0;
         min-height: auto;
@@ -1029,9 +1036,30 @@
     .us-travel-hero-combined {
         padding: 100px 1rem 60px;
     }
-    
+
+    .detail-intro {
+        text-align: left !important;
+        margin-left: 0;
+    }
+
+    .us-travel-hero-combined .container {
+        align-items: flex-start;
+        text-align: left !important;
+    }
+
+    .us-travel-hero-combined .hero-content {
+        text-align: left !important;
+    }
+
     .us-travel-hero-combined .hero-content h1 {
         letter-spacing: 2px;
+        justify-content: flex-start;
+        text-align: left !important;
+    }
+
+    .us-travel-hero-combined .hero-content p {
+        margin: 1rem 0 0;
+        text-align: left !important;
     }
     
     .us-travel-hero-combined .hero-content h1::after {


### PR DESCRIPTION
## Summary
- force the home page about section copy to stay left aligned on small screens by overriding the global mobile centering rule
- update the US Training Camp hero and detail copy to use left alignment on mobile so the paragraphs no longer center themselves

## Testing
- not run (static CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d5dd9806208322bf4e96ee89d53ac6