### PR TITLE
Refine US hero centering and remove program scroll prompts

### DIFF
--- a/programs/australia_travel_program.html
+++ b/programs/australia_travel_program.html
@@ -113,13 +113,6 @@
                 </div>
             </div>
             
-            <!-- Scroll indicator -->
-            <div class="aussie-scroll-indicator">
-                <div class="aussie-scroll-mouse">
-                    <div class="aussie-scroll-wheel"></div>
-                </div>
-                <span>Scroll to explore</span>
-            </div>
         </section>
 
         <!-- Content sections will go here -->

--- a/programs/professional_coaching.html
+++ b/programs/professional_coaching.html
@@ -156,13 +156,6 @@
                 </div>
             </div>
 
-            <!-- Scroll Indicator -->
-            <div class="coaching-scroll-indicator" onclick="scrollToSection('.how-it-works-section')">
-                <div class="coaching-scroll-mouse">
-                    <div class="coaching-scroll-wheel"></div>
-                </div>
-                <span>Scroll Down</span>
-            </div>
         </section>
 
 
@@ -259,7 +252,7 @@
             window.addEventListener('resize', apply);
         })();
 
-        // Scroll to section function for coaching scroll indicator
+        // Smooth scroll helper for hero buttons
         function scrollToSection(selector) {
             const targetSection = document.querySelector(selector);
             if (targetSection) {

--- a/programs/us_travel_program.html
+++ b/programs/us_travel_program.html
@@ -115,13 +115,6 @@
                
             </div>
             
-            <!-- Scroll indicator -->
-            <div class="us-scroll-indicator">
-                <div class="us-scroll-mouse">
-                    <div class="us-scroll-wheel"></div>
-                </div>
-                <span>Scroll to explore</span>
-            </div>
         </section>
 
         <!-- Experience Details -->

--- a/styles/australia.css
+++ b/styles/australia.css
@@ -161,54 +161,6 @@
     transform: translateY(-1px);
 }
 
-/* Scroll Indicator */
-.aussie-scroll-indicator {
-    position: absolute;
-    bottom: 30px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 3;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    color: rgba(255, 255, 255, 0.8);
-    text-align: center;
-    width: 100%;
-    max-width: 200px;
-    margin-left: -100px;
-    animation: aussieBounce 2s infinite;
-}
-
-.aussie-scroll-mouse {
-    width: 26px;
-    height: 42px;
-    border: 2px solid rgba(255, 255, 255, 0.8);
-    border-radius: 13px;
-    position: relative;
-    margin-bottom: 8px;
-}
-
-.aussie-scroll-wheel {
-    width: 4px;
-    height: 8px;
-    background: rgba(255, 255, 255, 0.8);
-    border-radius: 2px;
-    position: absolute;
-    top: 6px;
-    left: 50%;
-    transform: translateX(-50%);
-    animation: aussieScroll 2s infinite;
-}
-
-.aussie-scroll-indicator span {
-    font-family: 'Roboto Condensed', sans-serif;
-    font-size: 0.9rem;
-    font-weight: 300;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
 /* Content Section */
 .aussie-content-section {
     min-height: 100vh;
@@ -258,29 +210,6 @@
     }
 }
 
-@keyframes aussieBounce {
-    0%, 20%, 50%, 80%, 100% {
-        transform: translateY(0);
-    }
-    40% {
-        transform: translateY(-10px);
-    }
-    60% {
-        transform: translateY(-5px);
-    }
-}
-
-@keyframes aussieScroll {
-    0% {
-        opacity: 1;
-        transform: translateX(-50%) translateY(0);
-    }
-    100% {
-        opacity: 0;
-        transform: translateX(-50%) translateY(20px);
-    }
-}
-
 /* Responsive Design */
 @media (max-width: 768px) {
     .aussie-hero-content {
@@ -296,9 +225,6 @@
         font-size: 1.1rem;
     }
     
-    .aussie-scroll-indicator {
-        bottom: 20px;
-    }
 }
 
 @media (max-width: 480px) {
@@ -338,14 +264,6 @@ html {
     
     .aussie-title-section,
     .aussie-cta-section {
-        animation: none;
-    }
-    
-    .aussie-scroll-indicator {
-        animation: none;
-    }
-    
-    .aussie-scroll-wheel {
         animation: none;
     }
     

--- a/styles/coaching.css
+++ b/styles/coaching.css
@@ -272,54 +272,6 @@
   font-family: 'Oswald', sans-serif;
 }
 
-/* Scroll Indicator */
-.coaching-scroll-indicator {
-    position: absolute;
-    bottom: 30px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 3;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    color: rgba(255, 255, 255, 0.8);
-    text-align: center;
-    width: 100%;
-    max-width: 200px;
-    margin-left: -100px;
-    animation: coachingBounce 2s infinite;
-}
-
-.coaching-scroll-mouse {
-    width: 26px;
-    height: 42px;
-    border: 2px solid rgba(255, 255, 255, 0.8);
-    border-radius: 13px;
-    position: relative;
-    margin-bottom: 8px;
-}
-
-.coaching-scroll-wheel {
-    width: 4px;
-    height: 8px;
-    background: rgba(255, 255, 255, 0.8);
-    border-radius: 2px;
-    position: absolute;
-    top: 6px;
-    left: 50%;
-    transform: translateX(-50%);
-    animation: coachingScroll 2s infinite;
-}
-
-.coaching-scroll-indicator span {
-    font-family: 'Roboto Condensed', sans-serif;
-    font-size: 0.9rem;
-    font-weight: 300;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
 /* Animations */
 @keyframes coachingSlideUp {
     from {
@@ -340,29 +292,6 @@
     to {
         opacity: 1;
         transform: scale(1);
-    }
-}
-
-@keyframes coachingBounce {
-    0%, 20%, 50%, 80%, 100% {
-        transform: translateY(0);
-    }
-    40% {
-        transform: translateY(-10px);
-    }
-    60% {
-        transform: translateY(-5px);
-    }
-}
-
-@keyframes coachingScroll {
-    0% {
-        opacity: 1;
-        transform: translateX(-50%) translateY(0);
-    }
-    100% {
-        opacity: 0;
-        transform: translateX(-50%) translateY(20px);
     }
 }
 
@@ -401,9 +330,6 @@
         font-size: 0.9rem;
     }
     
-    .coaching-scroll-indicator {
-        bottom: 20px;
-    }
 }
 
 @media (max-width: 480px) {

--- a/styles/us.css
+++ b/styles/us.css
@@ -89,38 +89,31 @@
     padding: 0 clamp(1rem, 4vw, 2rem);
 }
 
+
 .us-travel-hero-combined .hero-content {
     text-align: center;
     max-width: 800px;
     position: relative;
     z-index: 2;
     animation: slideInDown 1.2s ease-out;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
 }
 
 .us-travel-hero-combined .hero-content h1 {
     font-family: 'Oswald', sans-serif;
     font-size: clamp(3.5rem, 8vw, 6rem);
     font-weight: 700;
-    margin-bottom: 1.5rem;
+    margin: 0;
     line-height: 0.9;
     text-transform: uppercase;
     letter-spacing: 3px;
     color: white;
     text-shadow: 0 2px 20px rgba(0, 0, 0, 0.8);
     text-align: center;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
     position: relative;
-    white-space: nowrap;
-}
-
-/* Allow text wrapping on smaller screens */
-@media (max-width: 768px) {
-    .us-travel-hero-combined .hero-content h1 {
-        white-space: normal;
-    }
 }
 
 .us-travel-hero-combined .hero-content p {
@@ -193,58 +186,14 @@
     transform: translateY(-1px);
 }
 
-/* Scroll Indicator */
-.us-scroll-indicator {
-    position: absolute;
-    bottom: 30px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 3;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    color: rgba(255, 255, 255, 0.8);
-    text-align: center;
-    width: 100%;
-    max-width: 200px;
-    margin-left: -100px;
-    animation: usBounce 2s infinite;
-}
-
-.us-scroll-mouse {
-    width: 26px;
-    height: 42px;
-    border: 2px solid rgba(255, 255, 255, 0.8);
-    border-radius: 13px;
-    position: relative;
-    margin-bottom: 8px;
-}
-
-.us-scroll-wheel {
-    width: 4px;
-    height: 8px;
-    background: rgba(255, 255, 255, 0.8);
-    border-radius: 2px;
-    position: absolute;
-    top: 6px;
-    left: 50%;
-    transform: translateX(-50%);
-    animation: usScroll 2s infinite;
-}
-
-.us-scroll-indicator span {
-    font-family: 'Roboto Condensed', sans-serif;
-    font-size: 0.9rem;
-    font-weight: 300;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
 /* Partnership Section Styles */
 .partnership-section {
     margin-top: 3rem;
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
 }
 
 .partnership-text {
@@ -254,7 +203,7 @@
     color: rgba(255, 255, 255, 0.8);
     text-transform: uppercase;
     letter-spacing: 2px;
-    margin-bottom: 2rem;
+    margin: 0;
 }
 
 .partner-logo {
@@ -310,29 +259,6 @@
     to {
         opacity: 1;
         transform: scale(1);
-    }
-}
-
-@keyframes usBounce {
-    0%, 20%, 50%, 80%, 100% {
-        transform: translateY(0);
-    }
-    40% {
-        transform: translateY(-10px);
-    }
-    60% {
-        transform: translateY(-5px);
-    }
-}
-
-@keyframes usScroll {
-    0% {
-        opacity: 1;
-        transform: translateX(-50%) translateY(0);
-    }
-    100% {
-        opacity: 0;
-        transform: translateX(-50%) translateY(20px);
     }
 }
 
@@ -448,21 +374,16 @@
     .partnership-section {
         margin-top: 2rem;
     }
-    
+
     .partnership-text {
         font-size: 0.9rem;
-        margin-bottom: 1.5rem;
     }
-    
+
     .clubmx-logo {
         max-height: 120px;
         max-width: 300px;
     }
-    
-    .us-scroll-indicator {
-        bottom: 20px;
-    }
-    
+
     .training-overview {
         flex-direction: column;
         gap: 1.5rem;
@@ -1010,13 +931,12 @@
     
     .detail-info {
         padding: 0 1rem;
-        text-align: left !important;
         margin-left: 0;
         margin-right: 0;
     }
 
     .detail-info p {
-        text-align: left !important;
+        text-align: left;
     }
 
     .experience-detail {
@@ -1033,41 +953,32 @@
         gap: 1.5rem;
     }
     
+    .detail-intro {
+        text-align: left;
+        margin-left: 0;
+    }
+
     .us-travel-hero-combined {
         padding: 100px 1rem 60px;
     }
 
-    .detail-intro {
-        text-align: left !important;
-        margin-left: 0;
-    }
-
-    .us-travel-hero-combined .container {
-        align-items: flex-start;
-        text-align: left !important;
-    }
-
     .us-travel-hero-combined .hero-content {
-        text-align: left !important;
+        align-items: center;
+        gap: 1.5rem;
     }
 
     .us-travel-hero-combined .hero-content h1 {
         letter-spacing: 2px;
-        justify-content: flex-start;
-        text-align: left !important;
     }
 
     .us-travel-hero-combined .hero-content p {
-        margin: 1rem 0 0;
-        text-align: left !important;
+        margin: 0;
     }
-    
-    .us-travel-hero-combined .hero-content h1::after {
-        width: 80px;
-        height: 3px;
-        bottom: -10px;
+
+    .facility-grid {
+        justify-items: stretch;
     }
-    
+
     .us-travel-hero-combined .pricing-details-btn {
         padding: 15px 30px;
         font-size: 1.1rem;
@@ -1565,6 +1476,27 @@
     margin-bottom: 3rem;
 }
 
+.detail-info .facility-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 1.5rem;
+}
+
+.detail-info .facility-section .section-header {
+    margin: 0;
+}
+
+.detail-info .facility-section .facility-grid {
+    width: 100%;
+    margin: 1.5rem auto 0;
+}
+
+.detail-info .facility-section .facility-feature {
+    text-align: left;
+}
+
 .facility-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -1848,14 +1780,6 @@
     .clubmx-logo,
     .training-image,
     .overview-content {
-        animation: none;
-    }
-    
-    .us-scroll-indicator {
-        animation: none;
-    }
-    
-    .us-scroll-wheel {
         animation: none;
     }
     


### PR DESCRIPTION
## Summary
- restore centered alignment for the US Training Camp hero content on small screens
- center the ClubMX facility section heading and grid while keeping detail text left aligned
- remove the "Scroll to explore" indicators and their styling from all program hero sections

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d6d347f488832287a7a6f44628e96a