### PR TITLE
Adjust US travel hero spacing

### DIFF
--- a/styles/us.css
+++ b/styles/us.css
@@ -99,7 +99,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2rem;
+    gap: clamp(1.25rem, 3vw, 2rem);
 }
 
 .us-travel-hero-combined .hero-content h1 {
@@ -188,7 +188,7 @@
 
 /* Partnership Section Styles */
 .partnership-section {
-    margin-top: 3rem;
+    margin-top: clamp(1.5rem, 4vw, 3rem);
     text-align: center;
     display: flex;
     flex-direction: column;
@@ -216,6 +216,24 @@
     max-height: 180px;
     max-width: 450px;
     filter: brightness(1.1) contrast(1.1);
+}
+
+@media (min-width: 1024px) {
+    .us-travel-hero-combined .hero-content {
+        gap: 1.5rem;
+    }
+
+    .us-travel-hero-combined .hero-content h1 {
+        white-space: nowrap;
+    }
+
+    .partnership-section {
+        margin-top: 1.75rem;
+    }
+
+    .us-travel-hero-combined .overview-cta {
+        margin-top: 2rem;
+    }
 }
 
 @keyframes fadeInUp {


### PR DESCRIPTION
## Summary
- tighten the hero layout spacing on the US travel program page
- prevent the desktop hero title from wrapping while keeping mobile wrapping

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d82c8c4080832280a44af02220180c