### PR TITLE
Update US travel copy to promote inquiries

### DIFF
--- a/programs/apply_us.html
+++ b/programs/apply_us.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Apply for US Travel Program - Join American Motorcycle Adventure | Moto Coach</title>
-    <meta name="description" content="Apply for Moto Coach's exclusive US Travel Program. Join our American motorcycle adventure tour with expert guides from Sydney. Limited spots available for this premium experience.">
-    <meta name="keywords" content="apply US travel program, American motorcycle tour application, US motorcycle adventure booking, international motorcycle tour application, premium motorcycle experience, Sydney to USA tour application">
+    <title>Inquire About the US Travel Program - Join American Motorcycle Adventure | Moto Coach</title>
+    <meta name="description" content="Inquire about Moto Coach's exclusive US Travel Program. Join our American motorcycle adventure tour with expert guides from Sydney. Limited spots available for this premium experience.">
+    <meta name="keywords" content="inquire US travel program, American motorcycle tour inquiry, US motorcycle adventure booking, international motorcycle tour inquiry, premium motorcycle experience, Sydney to USA tour inquiry">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/programs/apply_us">
     
@@ -29,8 +29,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/programs/apply_us">
-    <meta property="og:title" content="Apply for US Travel Program - Join American Motorcycle Adventure">
-    <meta property="og:description" content="Apply for Moto Coach's exclusive US Travel Program. Join our American motorcycle adventure tour with expert guides from Sydney.">
+    <meta property="og:title" content="Inquire About the US Travel Program - Join American Motorcycle Adventure">
+    <meta property="og:description" content="Inquire about Moto Coach's exclusive US Travel Program. Join our American motorcycle adventure tour with expert guides from Sydney.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -38,8 +38,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/programs/apply_us">
-    <meta property="twitter:title" content="Apply for US Travel Program - Join American Motorcycle Adventure">
-    <meta property="twitter:description" content="Apply for Moto Coach's exclusive US Travel Program. Limited spots available for this premium experience.">
+    <meta property="twitter:title" content="Inquire About the US Travel Program - Join American Motorcycle Adventure">
+    <meta property="twitter:description" content="Inquire about Moto Coach's exclusive US Travel Program. Limited spots available for this premium experience.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -106,11 +106,11 @@
                 </a>
             </div>
             
-            <!-- Application Form -->
+            <!-- Inquiry Form -->
             <div class="contact-form-container">
                 <div class="form-header">
-                    <h2>APPLICATION FORM</h2>
-                    <p>Complete the form below to apply for the US Training Camp at ClubMX. If there is an open spot, we will contact you.</p>
+                    <h2>INQUIRY FORM</h2>
+                    <p>Complete the form below to inquire for the US Training Camp at ClubMX. If there is an open spot, we will contact you.</p>
                 </div>
                 <form class="contact-form application-form" method="POST">
                     <!-- Personal Information -->

--- a/programs/us_travel_program.html
+++ b/programs/us_travel_program.html
@@ -129,7 +129,7 @@
                         <div class="detail-info">
                             <h3 id="training-heading">4-Week US Training Camp | ClubMX, South Carolina</h3>
                             <div class="top-apply-cta">
-                                <a href="apply_us" class="btn-experience training-btn">Apply Now</a>
+                                <a href="apply_us" class="btn-experience training-btn">Inquire Now</a>
                             </div>
                             <p class="detail-intro">The ultimate preparation for AJMX awaits. Join us for an elite 4-week motocross training experience at the world-renowned ClubMX facility. Positioned between the end of the Australian outdoor ProMX series and the start of the Australian Supercross series and AJMX. Train alongside top-level riders with pro-level coaching, facilities, and recovery resources.</p>
                             <p class="detail-intro">This is a specialised training program designed for riders to learn from the world's best coaches and elevate their racing performance. Experience one month of intensive training at ClubMX with professional team coaches, featuring comprehensive on-bike and off-bike training programs.</p>
@@ -320,7 +320,7 @@
                             </div>
                             
                             <div class="detail-cta">
-                                <a href="apply_us" class="btn-experience training-btn">Apply Now</a>
+                                <a href="apply_us" class="btn-experience training-btn">Inquire Now</a>
                                 <a href="../contact" class="btn-secondary">Get More Info</a>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- retitle the US Training Camp call-to-action buttons to say "Inquire Now"
- refresh the US inquiry page metadata and hero copy to reference inquiries instead of applications
- rename the visible form heading and instructions to "Inquiry Form"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8322ed7608322a9139bd501caaef5