### PR TITLE
Update SEO terminology to reflect motocross focus

### DIFF
--- a/api/apply_us.js
+++ b/api/apply_us.js
@@ -132,7 +132,7 @@ async function sendApplicantConfirmationEmail(formData, applicationId) {
                         <div style="background: #ff6600; color: white; padding: 20px; border-radius: 8px; text-align: center; margin: 30px 0;">
                             <h3 style="margin: 0 0 10px 0;">Ready for the Adventure?</h3>
                             <p style="margin: 0; font-size: 16px;">
-                                Get ready for an unforgettable motorcycle training experience at ClubMX in the USA!
+                                Get ready for an unforgettable motocross training experience at ClubMX in the USA!
                             </p>
                         </div>
                         

--- a/calendar.html
+++ b/calendar.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Schedule - Moto Coach Training Calendar | Sydney, Australia</title>
-    <meta name="description" content="View our upcoming motorcycle coaching sessions, track reserve dates, travel programs, and training events. Book your spot with Moto Coach Sydney's premier motorcycle training team.">
-    <meta name="keywords" content="motorcycle schedule, training calendar, track reserve dates, coaching sessions, Sydney motorcycle events, booking calendar, professional coaching schedule, Australia travel program dates">
+    <meta name="description" content="View our upcoming motocross coaching sessions, track reserve dates, travel programs, and training events. Book your spot with Moto Coach Sydney's premier dirt bike coaching team.">
+    <meta name="keywords" content="motocross schedule, training calendar, track reserve dates, coaching sessions, Sydney motocross events, booking calendar, professional motocross coaching schedule, Australia travel program dates">
     <meta name="author" content="Moto Coach">
                     <link rel="canonical" href="https://motocoach.com.au/calendar">    <!-- Security Headers -->
     <meta http-equiv="Content-Security-Policy"
@@ -25,7 +25,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/calendar">
     <meta property="og:title" content="Schedule - Moto Coach Training Calendar">
-    <meta property="og:description" content="View our upcoming motorcycle coaching sessions, track reserve dates, and travel programs. Book your spot with Sydney's premier motorcycle training team.">
+    <meta property="og:description" content="View our upcoming motocross coaching sessions, track reserve dates, and travel programs. Book your spot with Sydney's premier dirt bike coaching team.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -34,7 +34,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/calendar">
     <meta property="twitter:title" content="Schedule - Moto Coach Training Calendar">
-    <meta property="twitter:description" content="View our upcoming motorcycle coaching sessions, track reserve dates, and travel programs.">
+    <meta property="twitter:description" content="View our upcoming motocross coaching sessions, track reserve dates, and travel programs.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sydney Moto Coach - Premier Motocross Training & Travel Adventures | Sydney, Australia</title>
-    <meta name="description" content="Expert motorcycle coaching, professional training programs, and exciting travel adventures across Australia and the US. Based in Sydney, offering track reserve, vacation experiences, and personalized coaching sessions.">
-    <meta name="keywords" content="motorcycle coaching, motorbike training, Sydney motorcycle school, professional coaching, track reserve, Australia travel program, US travel program, motorcycle adventures, dirt bike coaching, Sydney Australia">
+    <meta name="description" content="Expert motocross coaching, professional dirt bike training programs, and exciting travel adventures across Australia and the US. Based in Sydney, offering track reserve, motocross camps, and personalized coaching sessions.">
+    <meta name="keywords" content="motocross coaching, dirt bike training, Sydney motocross school, professional motocross coaching, track reserve, Australia motocross travel program, US motocross travel program, motocross adventures, dirt bike coaching, Sydney Australia">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/">
     
@@ -16,7 +16,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/">
     <meta property="og:title" content="Sydney Moto Coach - Premier Motocross Training & Travel Adventures">
-    <meta property="og:description" content="Expert motorcycle coaching, professional training programs, and exciting travel adventures across Australia and the US. Based in Sydney.">
+    <meta property="og:description" content="Expert motocross coaching, professional dirt bike training programs, and exciting travel adventures across Australia and the US. Based in Sydney.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -25,7 +25,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/">
     <meta property="twitter:title" content="Sydney Moto Coach - Premier Motocross Training & Travel Adventures">
-    <meta property="twitter:description" content="Expert motorcycle coaching, professional training programs, and exciting travel adventures across Australia and the US.">
+    <meta property="twitter:description" content="Expert motocross coaching, professional dirt bike training programs, and exciting travel adventures across Australia and the US.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <!-- Security Headers -->

--- a/programs/apply_us.html
+++ b/programs/apply_us.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Inquire About the US Travel Program - Join American Motorcycle Adventure | Moto Coach</title>
-    <meta name="description" content="Inquire about Moto Coach's exclusive US Travel Program. Join our American motorcycle adventure tour with expert guides from Sydney. Limited spots available for this premium experience.">
-    <meta name="keywords" content="inquire US travel program, American motorcycle tour inquiry, US motorcycle adventure booking, international motorcycle tour inquiry, premium motorcycle experience, Sydney to USA tour inquiry">
+    <title>Inquire About the US Travel Program - Join American Motocross Adventure | Moto Coach</title>
+    <meta name="description" content="Inquire about Moto Coach's exclusive US Travel Program. Join our American motocross adventure tour with expert guides from Sydney. Limited spots available for this premium experience.">
+    <meta name="keywords" content="inquire US travel program, American motocross tour inquiry, US motocross adventure booking, international motocross tour inquiry, premium dirt bike experience, Sydney to USA tour inquiry">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/programs/apply_us">
     
@@ -29,8 +29,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/programs/apply_us">
-    <meta property="og:title" content="Inquire About the US Travel Program - Join American Motorcycle Adventure">
-    <meta property="og:description" content="Inquire about Moto Coach's exclusive US Travel Program. Join our American motorcycle adventure tour with expert guides from Sydney.">
+    <meta property="og:title" content="Inquire About the US Travel Program - Join American Motocross Adventure">
+    <meta property="og:description" content="Inquire about Moto Coach's exclusive US Travel Program. Join our American motocross adventure tour with expert guides from Sydney.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -38,8 +38,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/programs/apply_us">
-    <meta property="twitter:title" content="Inquire About the US Travel Program - Join American Motorcycle Adventure">
-    <meta property="twitter:description" content="Inquire about Moto Coach's exclusive US Travel Program. Limited spots available for this premium experience.">
+    <meta property="twitter:title" content="Inquire About the US Travel Program - Join American Motocross Adventure">
+    <meta property="twitter:description" content="Inquire about Moto Coach's exclusive US Travel Program. Limited spots available for this premium motocross experience.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/programs/australia_travel_program.html
+++ b/programs/australia_travel_program.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Aussie Moto Vacations - Adventure Motorcycle Tours | Moto Coach</title>
-    <meta name="description" content="Epic motorcycle adventures through Australia's outback. Guided tours, scenic routes, and unforgettable experiences across the Australian landscape with Moto Coach Sydney's expert guides.">
-    <meta name="keywords" content="Australia motorcycle tours, outback adventure, motorcycle travel program, guided tours Australia, adventure riding, scenic motorcycle routes, Australian outback tours, motorcycle experiences Sydney">
+    <title>Aussie Moto Vacations - Adventure Motocross Tours | Moto Coach</title>
+    <meta name="description" content="Epic motocross adventures through Australia's outback. Guided dirt bike tours, scenic routes, and unforgettable experiences across the Australian landscape with Moto Coach Sydney's expert guides.">
+    <meta name="keywords" content="Australia motocross tours, outback adventure, dirt bike travel program, guided tours Australia, adventure riding, scenic motocross routes, Australian outback tours, motocross experiences Sydney">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/programs/australia_travel_program">
     
@@ -15,8 +15,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/programs/australia_travel_program">
-    <meta property="og:title" content="Aussie Moto Vacations - Adventure Motorcycle Tours">
-    <meta property="og:description" content="Epic motorcycle adventures through Australia's outback. Guided tours, scenic routes, and unforgettable experiences with expert guides.">
+    <meta property="og:title" content="Aussie Moto Vacations - Adventure Motocross Tours">
+    <meta property="og:description" content="Epic motocross adventures through Australia's outback. Guided dirt bike tours, scenic routes, and unforgettable experiences with expert guides.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -24,8 +24,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/programs/australia_travel_program">
-    <meta property="twitter:title" content="Aussie Moto Vacations - Adventure Motorcycle Tours">
-    <meta property="twitter:description" content="Epic motorcycle adventures through Australia's outback. Guided tours and unforgettable experiences.">
+    <meta property="twitter:title" content="Aussie Moto Vacations - Adventure Motocross Tours">
+    <meta property="twitter:description" content="Epic motocross adventures through Australia's outback. Guided dirt bike tours and unforgettable experiences.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -94,7 +94,7 @@
                     <img src="../images/pexels-luis-la-79784941-8858270.jpg" alt="Australian Terrain">
                 </div>
                 <div class="aussie-slide">
-                    <img src="../images/pexels-catchavibe-1555453.jpg" alt="Australian Motorcycle Adventure">
+                    <img src="../images/pexels-catchavibe-1555453.jpg" alt="Australian Motocross Adventure">
                 </div>
             </div>
             
@@ -119,7 +119,7 @@
         <section id="pricing-details" class="aussie-content-section">
             <div class="container">
                 <h2>Coming Soon</h2>
-                <p>Epic Australian motorcycle adventures are in development. Stay tuned for incredible outback experiences.</p>
+                <p>Epic Australian motocross adventures are in development. Stay tuned for incredible outback experiences.</p>
             </div>
         </section>
     </main>

--- a/programs/professional_coaching.html
+++ b/programs/professional_coaching.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Professional Coaching - Expert Motorcycle Training | Moto Coach Sydney</title>
-    <meta name="description" content="Professional one-on-one motorcycle coaching with expert instructors. Personalized training sessions, track coaching, and skill development programs in Sydney. Improve your riding technique with Moto Coach.">
-    <meta name="keywords" content="professional motorcycle coaching, one-on-one training, motorcycle instructor Sydney, track coaching, riding technique, personalized training, motorcycle skills development, expert coaching Sydney">
+    <title>Professional Coaching - Expert Motocross Training | Moto Coach Sydney</title>
+    <meta name="description" content="Professional one-on-one motocross coaching with expert instructors. Personalized dirt bike training sessions, track coaching, and skill development programs in Sydney. Improve your riding technique with Moto Coach.">
+    <meta name="keywords" content="professional motocross coaching, one-on-one dirt bike training, motocross instructor Sydney, track coaching, riding technique, personalized training, motocross skills development, expert coaching Sydney">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/programs/professional_coaching">
     
@@ -15,8 +15,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/programs/professional_coaching">
-    <meta property="og:title" content="Professional Coaching - Expert Motorcycle Training">
-    <meta property="og:description" content="Professional one-on-one motorcycle coaching with expert instructors. Personalized training sessions and skill development programs in Sydney.">
+    <meta property="og:title" content="Professional Coaching - Expert Motocross Training">
+    <meta property="og:description" content="Professional one-on-one motocross coaching with expert instructors. Personalized dirt bike training sessions and skill development programs in Sydney.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -24,8 +24,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/programs/professional_coaching.html">
-    <meta property="twitter:title" content="Professional Coaching - Expert Motorcycle Training">
-    <meta property="twitter:description" content="Professional one-on-one motorcycle coaching with expert instructors. Personalized training sessions in Sydney.">
+    <meta property="twitter:title" content="Professional Coaching - Expert Motocross Training">
+    <meta property="twitter:description" content="Professional one-on-one motocross coaching with expert instructors. Personalized dirt bike training sessions in Sydney.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/programs/track_reserve.html
+++ b/programs/track_reserve.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Track Reservation - Book Your Motorcycle Training Session | Moto Coach Sydney</title>
-    <meta name="description" content="Reserve your motorcycle training session at premium tracks with Moto Coach. Book track time, coaching sessions, and skill development programs in Sydney and across Australia.">
-    <meta name="keywords" content="track reservation, motorcycle track booking, training session booking, track time Sydney, motorcycle coaching booking, track reserve Australia, professional track training, Sydney motorcycle tracks">
+    <title>Track Reservation - Book Your Motocross Training Session | Moto Coach Sydney</title>
+    <meta name="description" content="Reserve your motocross training session at premium tracks with Moto Coach. Book track time, dirt bike coaching sessions, and skill development programs in Sydney and across Australia.">
+    <meta name="keywords" content="track reservation, motocross track booking, training session booking, track time Sydney, motocross coaching booking, track reserve Australia, professional dirt bike training, Sydney motocross tracks">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/programs/track_reserve">
     
@@ -29,8 +29,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/programs/track_reserve">
-    <meta property="og:title" content="Track Reservation - Book Your Motorcycle Training Session">
-    <meta property="og:description" content="Reserve your motorcycle training session at premium tracks with Moto Coach. Book track time and coaching sessions in Sydney.">
+    <meta property="og:title" content="Track Reservation - Book Your Motocross Training Session">
+    <meta property="og:description" content="Reserve your motocross training session at premium tracks with Moto Coach. Book track time and dirt bike coaching sessions in Sydney.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -38,8 +38,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/programs/track_reserve">
-    <meta property="twitter:title" content="Track Reservation - Book Your Motorcycle Training Session">
-    <meta property="twitter:description" content="Reserve your motorcycle training session at premium tracks with Moto Coach.">
+    <meta property="twitter:title" content="Track Reservation - Book Your Motocross Training Session">
+    <meta property="twitter:description" content="Reserve your motocross training session at premium tracks with Moto Coach.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/programs/us_travel_program.html
+++ b/programs/us_travel_program.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>US Training Camp - American Motorcycle Adventures | Moto Coach</title>
-    <meta name="description" content="Experience the ultimate American motorcycle adventure with Moto Coach. Guided tours across the US, professional training, and unforgettable riding experiences from Sydney-based motorcycle experts.">
-    <meta name="keywords" content="US motorcycle tours, American motorcycle adventure, USA travel program, international motorcycle tours, motorcycle training USA, guided tours America, adventure riding USA, Sydney to USA motorcycle">
+    <title>US Training Camp - American Motocross Adventures | Moto Coach</title>
+    <meta name="description" content="Experience the ultimate American motocross adventure with Moto Coach. Guided dirt bike tours across the US, professional training, and unforgettable riding experiences from Sydney-based motocross experts.">
+    <meta name="keywords" content="US motocross tours, American motocross adventure, USA travel program, international motocross tours, motocross training USA, guided dirt bike tours America, adventure riding USA, Sydney to USA motocross">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/programs/us_travel_program">
     
@@ -15,8 +15,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/programs/us_travel_program">
-    <meta property="og:title" content="US Training Camp - American Motorcycle Adventures">
-    <meta property="og:description" content="Experience the ultimate American motorcycle adventure with Moto Coach. Guided tours across the US and professional training.">
+    <meta property="og:title" content="US Training Camp - American Motocross Adventures">
+    <meta property="og:description" content="Experience the ultimate American motocross adventure with Moto Coach. Guided dirt bike tours across the US and professional training.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -24,8 +24,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/programs/us_travel_program">
-    <meta property="twitter:title" content="US Training Camp - American Motorcycle Adventures">
-    <meta property="twitter:description" content="Experience the ultimate American motorcycle adventure with Moto Coach. Guided tours and training.">
+    <meta property="twitter:title" content="US Training Camp - American Motocross Adventures">
+    <meta property="twitter:description" content="Experience the ultimate American motocross adventure with Moto Coach. Guided dirt bike tours and training.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/shop.html
+++ b/shop.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Shop - Moto Coach Gear & Equipment | Sydney, Australia</title>
-    <meta name="description" content="Browse our selection of premium motorcycle gear, training equipment, and Moto Coach branded merchandise. Quality products for serious riders and training enthusiasts in Sydney and across Australia.">
-    <meta name="keywords" content="motorcycle gear, training equipment, moto coach merchandise, motorcycle accessories, riding gear, Sydney motorcycle shop, premium motorcycle equipment, dirt bike gear">
+    <meta name="description" content="Browse our selection of premium motocross gear, dirt bike training equipment, and Moto Coach branded merchandise. Quality products for serious riders and training enthusiasts in Sydney and across Australia.">
+    <meta name="keywords" content="motocross gear, dirt bike equipment, moto coach merchandise, motocross accessories, riding gear, Sydney motocross shop, premium dirt bike equipment, motocross apparel">
     <meta name="author" content="Moto Coach">
     <link rel="canonical" href="https://motocoach.com.au/shop">
     
@@ -29,7 +29,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://motocoach.com.au/shop">
     <meta property="og:title" content="Shop - Moto Coach Gear & Equipment">
-    <meta property="og:description" content="Browse our selection of premium motorcycle gear, training equipment, and Moto Coach branded merchandise. Quality products for serious riders.">
+    <meta property="og:description" content="Browse our selection of premium motocross gear, dirt bike training equipment, and Moto Coach branded merchandise. Quality products for serious riders.">
     <meta property="og:image" content="https://motocoach.com.au/images/long-logo.png">
     <meta property="og:site_name" content="Moto Coach">
     <meta property="og:locale" content="en_AU">
@@ -38,7 +38,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://motocoach.com.au/shop">
     <meta property="twitter:title" content="Shop - Moto Coach Gear & Equipment">
-    <meta property="twitter:description" content="Browse our selection of premium motorcycle gear, training equipment, and Moto Coach branded merchandise.">
+    <meta property="twitter:description" content="Browse our selection of premium motocross gear, dirt bike training equipment, and Moto Coach branded merchandise.">
     <meta property="twitter:image" content="https://motocoach.com.au/images/long-logo.png">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- replace SEO metadata across the home, shop, and calendar pages to emphasize motocross and dirt bike terminology
- align program pages and supporting travel content with motocross-focused messaging, including alt text updates
- adjust US program confirmation email copy to promise a motocross training experience at ClubMX

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db0c23ff2c8322b40634a2fdf31933