### PR TITLE
Refine event transfer and update track reserve workflow

### DIFF
--- a/api/track_reserve.js
+++ b/api/track_reserve.js
@@ -261,11 +261,11 @@ async function checkEventAvailability(formData, riderCount) {
             const currentRegistrations = registrations.filter(row => {
                 const registeredEventName = row[1] || ''; // Column B: Event Name
                 const registeredEventDate = row[2] || ''; // Column C: Event Date
-                
+
                 // Match by both event name and date for accuracy
                 const eventNameMatch = registeredEventName.trim().toLowerCase() === event.title.trim().toLowerCase();
-                const eventDateMatch = registeredEventDate === event.date;
-                
+                const eventDateMatch = formatAustralianDate(registeredEventDate) === formatAustralianDate(event.date);
+
                 return eventNameMatch && eventDateMatch;
             }).length;
 

--- a/api/track_reserve.js
+++ b/api/track_reserve.js
@@ -47,8 +47,8 @@ function formatAustralianDate(value) {
 
     return parsed.toLocaleDateString('en-AU', {
         timeZone: 'Australia/Sydney',
-        day: '2-digit',
-        month: '2-digit',
+        day: 'numeric',
+        month: 'numeric',
         year: 'numeric'
     });
 }

--- a/programs/track_reserve.html
+++ b/programs/track_reserve.html
@@ -262,19 +262,6 @@
                         </div>
                     </div>
 
-                    <!-- Payment Information -->
-                    <div class="form-section-header">
-                        <h3>Payment Information</h3>
-                        <p style="color: #ccc; margin: 0; font-size: 0.9em;">Choose your preferred payment method</p>
-                    </div>
-                    
-                    <!-- Single Payment Element Container (Stripe handles method switching) -->
-                    <div class="payment-element-container">
-                        <div id="payment-element"></div>
-                    </div>
-                    
-                    <div id="payment-errors" style="color: #dc3545; margin: 10px 0; display: none;"></div>
-
                     <div class="form-submit">
                         <button type="submit" class="btn-register btn-large">Continue to checkout</button>
                     </div>

--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -1,3 +1,5 @@
+const TRACK_RESERVE_TRANSFER_PREFIX = 'TRACK_RESERVE::';
+
 class MotoCoachCalendar {
     constructor() {
         this.currentDate = new Date();
@@ -1160,6 +1162,10 @@ class MotoCoachCalendar {
         this.selectedEvents.clear();
         this.updateSelectionUI();
         this.updateButtonStatesOnly(); // Only update button states, don't refresh all event details
+
+        if (typeof window !== 'undefined' && typeof window.name === 'string' && window.name.startsWith(TRACK_RESERVE_TRANSFER_PREFIX)) {
+            window.name = '';
+        }
     }
 
     proceedToRegistration() {
@@ -1219,13 +1225,23 @@ class MotoCoachCalendar {
             pricingInfo
         };
 
+        const transferEnvelope = {
+            ...transferPayload,
+            timestamp: Date.now()
+        };
+
         try {
-            sessionStorage.setItem('trackReserveEventDetails', JSON.stringify({
-                ...transferPayload,
-                timestamp: Date.now()
-            }));
+            sessionStorage.setItem('trackReserveEventDetails', JSON.stringify(transferEnvelope));
         } catch (error) {
             console.warn('Unable to persist selected events for track reservation transfer', error);
+        }
+
+        if (typeof window !== 'undefined') {
+            try {
+                window.name = `${TRACK_RESERVE_TRANSFER_PREFIX}${JSON.stringify(transferEnvelope)}`;
+            } catch (error) {
+                console.warn('Unable to persist selected events using window.name fallback', error);
+            }
         }
 
         window.location.href = 'programs/track_reserve.html';

--- a/scripts/track_reserve.js
+++ b/scripts/track_reserve.js
@@ -52,8 +52,8 @@ function formatAustralianDateString(value) {
 
     return parsed.toLocaleDateString('en-AU', {
         timeZone: 'Australia/Sydney',
-        day: '2-digit',
-        month: '2-digit',
+        day: 'numeric',
+        month: 'numeric',
         year: 'numeric'
     });
 }

--- a/scripts/track_reserve.js
+++ b/scripts/track_reserve.js
@@ -1148,7 +1148,7 @@ function buildRegistrationPayload(form, totalAmount) {
             dateString: eventDetails.dateString || data.eventDate,
             time: eventDetails.time || data.eventTime,
             location: eventDetails.location || data.eventLocation,
-            maxSpots: eventDetails.maxSpots ?? maxSpots || null,
+            maxSpots: eventDetails.maxSpots ?? (typeof maxSpots !== 'undefined' && maxSpots !== null ? maxSpots : null),
             remainingSpots: eventDetails.remainingSpots ?? remainingSpots
         }];
     }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1659,6 +1659,37 @@ footer {
     background-color: #5a6268;
 }
 
+.btn-register {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 1rem 1.5rem;
+    font-family: 'Oswald', sans-serif;
+    font-size: 1.05rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    background: linear-gradient(135deg, #ff6b35, #f8552e);
+    color: #ffffff;
+    border: none;
+    border-radius: 10px;
+    box-shadow: 0 12px 24px rgba(255, 107, 53, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn-register:hover {
+    background: linear-gradient(135deg, #ff824f, #ff5e2b);
+    transform: translateY(-2px);
+    box-shadow: 0 16px 28px rgba(255, 107, 53, 0.45);
+}
+
+.btn-register:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
 /* Australian date input styling */
 input[type="text"][pattern*="DD/MM/YYYY"],
 input[placeholder="DD/MM/YYYY"] {


### PR DESCRIPTION
## Summary
- persist multi-event selections in session storage instead of query strings and reset the calendar selection panel properly
- rework the track reserve page to load events from stored context, validate them via the API, and streamline the form by removing the payment section
- style the Continue to checkout button for better visual prominence

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68db1c67fe208322bc5b26f3e773d030